### PR TITLE
Bugfix/incorrect hopsworks pk

### DIFF
--- a/services/earthquake_producer/poetry.lock
+++ b/services/earthquake_producer/poetry.lock
@@ -904,19 +904,19 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
+version = "4.3.7"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
+    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "prompt-toolkit"

--- a/services/earthquake_producer/src/config.py
+++ b/services/earthquake_producer/src/config.py
@@ -11,6 +11,7 @@ class Config(BaseSettings):
 
     last_n_days: int = 30
     limit: int = 20000
+    time_interval: int = 60 * 5
 
     @field_validator("live_or_historical")
     @classmethod

--- a/services/earthquake_producer/src/seismic_portal_api/earthquake.py
+++ b/services/earthquake_producer/src/seismic_portal_api/earthquake.py
@@ -13,3 +13,4 @@ class Earthquake(BaseModel):
     depth: float
     latitude: float
     longitude: float
+    uuid: str

--- a/services/earthquake_producer/src/seismic_portal_api/utils.py
+++ b/services/earthquake_producer/src/seismic_portal_api/utils.py
@@ -1,0 +1,39 @@
+from dateutil import parser
+from datetime import timezone
+from src.seismic_portal_api.earthquake import Earthquake
+
+import uuid
+import hashlib
+
+def to_ms(timestamp: str) -> int:
+    """
+    A function that transforms a UTC timestamp expressed
+    as a string like this '2024-06-17T09:36:39.467866Z'
+    into a timestamp expressed in milliseconds such as
+    1718616999000.
+
+    Args:
+        timestamp (str): A timestamp expressed as a string.
+
+    Returns:
+        int: A timestamp expressed in milliseconds.
+    """
+
+    timestamp = parser.isoparse(timestamp).astimezone(timezone.utc)
+    return int(timestamp.timestamp()) * 1000
+
+def generate_earthquake_uuid(region: str, timestamp: int, magnitude: float) -> str:
+    """
+    A function that generates a unique identifier for an earthquake.
+
+    Args:
+        earthquake (Earthquake): An Earthquake model.
+
+    Returns:
+        str: A unique identifier (UUID) for the earthquake.
+    """
+    uuid_str = hashlib.md5(
+        f"{region}-{str(timestamp)}-{str(magnitude)}".encode()
+    ).hexdigest()
+
+    return uuid.UUID(hex=uuid_str)

--- a/services/earthquake_producer/src/seismic_portal_api/websocket.py
+++ b/services/earthquake_producer/src/seismic_portal_api/websocket.py
@@ -4,6 +4,7 @@ import ssl
 from loguru import logger
 from websocket import create_connection
 from src.seismic_portal_api.earthquake import Earthquake
+from src.seismic_portal_api.utils import to_ms, generate_earthquake_uuid
 
 
 class SeismicPortalAPI:
@@ -45,36 +46,24 @@ class SeismicPortalAPI:
 
         msg_contents = msg["data"]["properties"]
 
-        timestamp = self.to_ms(msg_contents["time"])
+        region = msg_contents["flynn_region"]
+        timestamp = to_ms(msg_contents["time"])
+        magnitude = msg_contents["mag"]
 
+        uuid = generate_earthquake_uuid(
+            region,
+            timestamp,
+            magnitude,
+        )
         earthquake = Earthquake(
             timestamp=timestamp,
             datestr=msg_contents["time"][:10],
             latitude=msg_contents["lat"],
             longitude=msg_contents["lon"],
             depth=msg_contents["depth"],
-            magnitude=msg_contents["mag"],
-            region=msg_contents["flynn_region"],
+            magnitude=magnitude,
+            region=region,
+            uuid=uuid,
         )
 
         return [earthquake]
-
-    @staticmethod
-    def to_ms(timestamp: str) -> int:
-        """
-        A function that transforms a UTC timestamp expressed
-        as a string like this '2024-06-17T09:36:39.467866Z'
-        into a timestamp expressed in milliseconds such as
-        1718616999000.
-
-        Args:
-            timestamp (str): A timestamp expressed as a string.
-
-        Returns:
-            int: A timestamp expressed in milliseconds.
-        """
-        from dateutil import parser
-        from datetime import timezone
-
-        timestamp = parser.isoparse(timestamp).astimezone(timezone.utc)
-        return int(timestamp.timestamp()) * 1000

--- a/services/seismic_data_sink/poetry.lock
+++ b/services/seismic_data_sink/poetry.lock
@@ -46,17 +46,17 @@ zstandard = ["zstandard"]
 
 [[package]]
 name = "boto3"
-version = "1.37.14"
+version = "1.37.17"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.37.14-py3-none-any.whl", hash = "sha256:56b4d1e084dbca43d5fdd070f633a84de61a6ce592655b4d239d263d1a0097fc"},
-    {file = "boto3-1.37.14.tar.gz", hash = "sha256:cf2e5e6d56efd5850db8ce3d9094132e4759cf2d4b5fd8200d69456bf61a20f3"},
+    {file = "boto3-1.37.17-py3-none-any.whl", hash = "sha256:3e7c2056b0e7950818c4b8695ac0da3a7933cf9f4f45d67f8804ce37fdef8a7b"},
+    {file = "boto3-1.37.17.tar.gz", hash = "sha256:f4ae383aca1799061d83c0097e9ccd7b494a71b36d72226628ad0fde1b95b7c9"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.14,<1.38.0"
+botocore = ">=1.37.17,<1.38.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -65,13 +65,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.14"
+version = "1.37.17"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.37.14-py3-none-any.whl", hash = "sha256:709a1796f436f8e378e52170e58501c1f3b5f2d1308238cf1d6a3bdba2e32851"},
-    {file = "botocore-1.37.14.tar.gz", hash = "sha256:b0adce3f0fb42b914eb05079f50cf368cb9cf9745fdd206bd91fe6ac67b29aca"},
+    {file = "botocore-1.37.17-py3-none-any.whl", hash = "sha256:f8c93eec385a346c7a59efcb15d8cf3613cd9d6ab27f32492eed9549bd86d69e"},
+    {file = "botocore-1.37.17.tar.gz", hash = "sha256:c879c2a5dc6952b81591d0e765c7b93e90df7f6c50b3d9b68011ec7cfe7fe48d"},
 ]
 
 [package.dependencies]

--- a/services/seismic_data_sink/src/hopsworks_api.py
+++ b/services/seismic_data_sink/src/hopsworks_api.py
@@ -41,7 +41,7 @@ def push_data_to_feature_store(
         name=feature_group_name,
         version=feature_group_version,
         description="Earthquake data from Seismic Portal",
-        primary_key=["region"],
+        primary_key=["uuid"],
         partition_key=[partition_key],
         event_time="timestamp",
         online_enabled=True,


### PR DESCRIPTION
- Declared UUID as PK instead of region or timestamp. UUID is based on:
  - `region` (str): region where the earthquake occurred
  - `timestamp` (int): time when the earthquake occurred
  - `magnitude` (float): magnitude of the earthquake
- Removed reliance on `time_interval` to determine uniqueness